### PR TITLE
Move to more stable servers

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,57 +6,23 @@ var fs = require('fs')
  * and that are up to date with the latest 1.1.5 version
  */
 var sks_servers = [
-    "ams.sks.heypete.com"
-  , "pgpkeys.co.uk"
-  , "keys.digitalis.org"
-  , "keys2.kfwebs.net"
-  , "keyserver.lsuhscshreveport.edu"
-  , "sks.undergrid.net"
-//  , "sks.openpgp-keyserver.de"
-//  , "keyserver.za.nucli.net"
-//  , "keyserver.nucli.net"
-//  , "keyserver.witopia.net"
-//  , "keyserver.br.nucli.net" timeout
-//  , "keys.fedoraproject.org" certificate not trusted
-//  , "keys.jhcloos.com" certificate has expired
-//  , "keys.niif.hu" unable to verify the first certificate
-//  , "keys.techwolf12.nl" timeout
-//  , "keyserver.zap.org.au" self signed certificate in certificate chain
-//  , "pgp.mit.edu" self signed certificate in certificate chain
-//  , "sks.alpha-labs.net" certificate not trusted
-//  , "sks.daylightpirates.org" certificate not trusted
-//  , "sks.karotte.org" timeout
-//  , "sks.spodhuis.org" self signed certificate in certificate chain
-//  , "zimmermann.mayfirst.org" unable to verify the first certificate
-//  , "keyserver.ut.mephi.ru" timeout
-//  , "pgp.archreactor.org" getaddrinfo ENOTFOUND
-//  , "keyserver.codinginfinity.com" certificate not trusted
-//  , "keys.alderwick.co.uk" certificate has expired
-//  , "keys2.alderwick.co.uk" certificate has expired
-//  , "keyserver.secure-u.de" certificate has expired
-//  , "a.keyserver.pki.scientia.net" certificate has expired
-//  , "keyserver.secretresearchfacility.com" certificate has expired
-//  , "keyserver.stack.nl" certificate has expired
-//  , "klucze.achjoj.info" certificate has expired
-//  , "pgpkeys.eu" certificate has expired
+  "pgp.key-server.io"
+  , "keyserver.ubuntu.com"
+  , "key.ip6.li"
 ];
 
-var getSKSserver = function() {
-  var index = Math.floor(Math.random()*sks_servers.length);
-  // console.log("Using "+"https://"+sks_servers[index]);
+var getSKSserver = function(idx) {
+  var index = idx || Math.floor(Math.random()*sks_servers.length);
   return "https://"+sks_servers[index];
 };
 
-var requestOptions = {
-  agentOptions: {
-    ca: fs.readFileSync(__dirname+'/sks-keyservers.netCA.pem')
-  }
-};
+var requestOptions = {};
 
 module.exports = {
 
-  index: function(email, fn) {
+  keyServers: sks_servers,
 
+  index: function(email, fn) {
     requestOptions.url = getSKSserver() + "/pks/lookup?search="+encodeURIComponent(email)+"&op=index&fingerprint=on&options=mr";
     request(requestOptions, function(err, res, body) {
       if(err) console.error(err);

--- a/index.js
+++ b/index.js
@@ -11,8 +11,8 @@ var sks_servers = [
   , "key.ip6.li"
 ];
 
-var getSKSserver = function(idx) {
-  var index = idx || Math.floor(Math.random()*sks_servers.length);
+var getSKSserver = function() {
+  var index = Math.floor(Math.random()*sks_servers.length);
   return "https://"+sks_servers[index];
 };
 
@@ -23,11 +23,12 @@ module.exports = {
   keyServers: sks_servers,
 
   index: function(email, fn) {
-    requestOptions.url = getSKSserver() + "/pks/lookup?search="+encodeURIComponent(email)+"&op=index&fingerprint=on&options=mr";
+    var selectedHost = getSKSserver()
+    requestOptions.url = selectedHost + "/pks/lookup?search="+encodeURIComponent(email)+"&op=index&fingerprint=on&options=mr";
     request(requestOptions, function(err, res, body) {
-      if(err) console.error(err);
-      if(err) return fn(err);
-      if(res.statusCode != 200) return fn(new Error("Not Found"));
+      if(err) console.error(err, selectedHost);
+      if(err) return fn(new Error(err.message + " - Host:" + selectedHost));
+      if(res.statusCode != 200) return fn(new Error("Not Found - Host:" + selectedHost));
 
 
       var lines = body.split('\n');

--- a/test/pgpsearch.spec.js
+++ b/test/pgpsearch.spec.js
@@ -1,12 +1,40 @@
 var openpgp = require('openpgp');
 var expect = require('chai').expect;
 var pgpsearch = require('../');
+var request = require('request');
 
 var email = "xdamman@gmail.com";
 var fingerprint = "44A7D05FF1F6D0B80F7915A614261B13FD430CDC";
 
 
 describe("pgp", function() {
+
+  it("All the servers should work", function(done) {
+    this.timeout(10*1000);
+    var n = pgpsearch.keyServers.length
+    var complete = 0
+
+    function response(err, res, body) {
+      if (err) {
+        done(err)
+      }
+      if (res.statusCode !== 200) {
+        done(new Error("Error: Status: " + res.statusCode))
+      }
+      complete = complete + 1
+      if (complete === n) {
+        done()
+      }
+    }
+
+    for (var i=0; i < pgpsearch.keyServers.length; i++) {
+      var requestOptions = {};
+      requestOptions.url = "https://" +pgpsearch.keyServers[i] + "/pks/lookup?search="+encodeURIComponent(email)+"&op=index&fingerprint=on&options=mr";
+      request(requestOptions, response)
+    }
+
+  });
+
 
   it("Finds the public PGP key for an email address", function(done) {
 


### PR DESCRIPTION
- Update to key servers that respond with SSL and seem more stable
- Send back the host with the error for easier debugging which host is behind the error
- Test all the servers to ensure that they are all working.