### PR TITLE
Handle revoked keys and add extra security

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,10 @@ module.exports = {
         if(l.substr(0,3) == 'pub') {
           var cols = l.split(':');
           if(cols[1].length == 40)
-            keys.push({fingerprint: cols[1], bits: cols[3], date: new Date(parseInt(cols[4]+'000',10)) });
+	    var f = null;
+	    if cols.length == 7:
+	      f = cols[6];
+            keys.push({fingerprint: cols[1], bits: cols[3], date: new Date(parseInt(cols[4]+'000',10)), flags: f });
           else {
             console.error("Invalid PGP fingerprint: ", cols[1]);
           }

--- a/index.js
+++ b/index.js
@@ -22,9 +22,13 @@ module.exports = {
 
   keyServers: sks_servers,
 
-  index: function(email, fn) {
+  index: function(email, fn, exact_match=false) {
     var selectedHost = getSKSserver()
-    requestOptions.url = selectedHost + "/pks/lookup?search="+encodeURIComponent(email)+"&op=index&fingerprint=on&options=mr";
+    var extraArgs = "";
+    if (exact_match) {
+      extraArgs = "&exact=on";
+    }
+    requestOptions.url = selectedHost + "/pks/lookup?search="+encodeURIComponent(email)+"&op=index&fingerprint=on&options=mr" + extraArgs;
     request(requestOptions, function(err, res, body) {
       if(err) console.error(err, selectedHost);
       if(err) return fn(new Error(err.message + " - Host:" + selectedHost));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-pgp-search",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Search for a PGP key by email address using SKS Key Servers",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
Hi Xavier,

I've faced an issue with a tipbox user where he had two keys, one revoked and both were showed up as selectable in tipbox. This is mainly because the revoked flag is not passed through tipbox from the PGP server. In this pull request, I:

 * Add the last column of the 'pub' entry as the 'flags' var, so when it contains a 'r', we know the key is revoked
* Added the 'exact_match' feature, so in tipbox we can eventually search for an email with an exact match, which I think would add a layer of extra security.

Let me know what you think.

--Thomas